### PR TITLE
set version 1.4.0: add tooltip property to TestSuiteInfo and TestInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-test-adapter-api",
   "description": "API for test adapters for the VS Code test explorer",
   "author": "Holger Benl <hbenl@evandor.de>",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,9 @@ export interface TestSuiteInfo {
 	/** The label to be displayed by the Test Explorer for this suite. */
 	label: string;
 
+	/** The tooltip text when you hover over this suite. */
+	tooltip?: string;
+
 	/**
 	 * The file containing this suite (if known).
 	 * This can either be an absolute path (if it is a local file) or a URI.
@@ -192,6 +195,9 @@ export interface TestInfo {
 
 	/** The label to be displayed by the Test Explorer for this test. */
 	label: string;
+
+	/** The tooltip text when you hover over this test. */
+	tooltip?: string;
 
 	/**
 	 * The file containing this test (if known).


### PR DESCRIPTION
If you accepted this pull request I would create the counterpart too for Test Explorer.

I would use this field to give more info about the suites and tests. For example: executable path; test name (it would be helpful when the label is too long)